### PR TITLE
DDP Backend Support

### DIFF
--- a/src/emmental/emmental-default-config.yaml
+++ b/src/emmental/emmental-default-config.yaml
@@ -15,6 +15,7 @@ model_config:
     model_path: # path to pretrained model
     device: 0 # -1 for cpu or gpu id (e.g., 0 for cuda:0)
     dataparallel: True # whether to use dataparallel or not
+    distributed_backend: nccl # what distributed backend to use for DDP [nccl, gloo]
 
 # Learning configuration
 learner_config:

--- a/src/emmental/meta.py
+++ b/src/emmental/meta.py
@@ -209,4 +209,4 @@ class Meta(object):
             Meta.config["model_config"]["device"] = torch.device(
                 "cuda", Meta.config["learner_config"]["local_rank"]
             )
-            torch.distributed.init_process_group(backend="nccl")
+            torch.distributed.init_process_group(backend=Meta.config["model_config"]["distributed_backend"])

--- a/src/emmental/meta.py
+++ b/src/emmental/meta.py
@@ -209,4 +209,6 @@ class Meta(object):
             Meta.config["model_config"]["device"] = torch.device(
                 "cuda", Meta.config["learner_config"]["local_rank"]
             )
-            torch.distributed.init_process_group(backend=Meta.config["model_config"]["distributed_backend"])
+            torch.distributed.init_process_group(
+                backend=Meta.config["model_config"]["distributed_backend"]
+            )

--- a/src/emmental/model.py
+++ b/src/emmental/model.py
@@ -86,6 +86,9 @@ class EmmentalModel(nn.Module):
 
     def _to_distributed_dataparallel(self) -> None:
         for key in self.module_pool.keys():
+            # Ensure there is some gradient parameter for DDP
+            if not any(p.requires_grad for p in self.module_pool[key].parameters()):
+                continue
             self.module_pool[
                 key
             ] = torch.nn.parallel.DistributedDataParallel(  # type: ignore

--- a/src/emmental/utils/parse_args.py
+++ b/src/emmental/utils/parse_args.py
@@ -93,6 +93,14 @@ def parse_args(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
         help="Whether to use dataparallel or not",
     )
 
+    model_config.add_argument(
+        "--distributed_backend",
+        type=str,
+        default='nccl',
+        choices=['nccl', 'gloo'],
+        help="Which backend to use for distributed training.",
+    )
+
     # Learning configuration
     learner_config = parser.add_argument_group("Learning configuration")
 
@@ -855,6 +863,7 @@ def parse_args_to_config(args: Namespace) -> Dict[str, Any]:
             "model_path": args.model_path,
             "device": args.device,
             "dataparallel": args.dataparallel,
+            "distributed_backend": args.distributed_backend
         },
         "learner_config": {
             "fp16": args.fp16,

--- a/src/emmental/utils/parse_args.py
+++ b/src/emmental/utils/parse_args.py
@@ -96,8 +96,8 @@ def parse_args(parser: Optional[ArgumentParser] = None) -> ArgumentParser:
     model_config.add_argument(
         "--distributed_backend",
         type=str,
-        default='nccl',
-        choices=['nccl', 'gloo'],
+        default="nccl",
+        choices=["nccl", "gloo"],
         help="Which backend to use for distributed training.",
     )
 
@@ -863,7 +863,7 @@ def parse_args_to_config(args: Namespace) -> Dict[str, Any]:
             "model_path": args.model_path,
             "device": args.device,
             "dataparallel": args.dataparallel,
-            "distributed_backend": args.distributed_backend
+            "distributed_backend": args.distributed_backend,
         },
         "learner_config": {
             "fp16": args.fp16,

--- a/tests/utils/test_parse_args.py
+++ b/tests/utils/test_parse_args.py
@@ -38,7 +38,7 @@ def test_parse_args(caplog):
             "use_exact_log_path": False,
         },
         "data_config": {"min_data_len": 0, "max_data_len": 0},
-        "model_config": {"model_path": None, "device": 0, "dataparallel": True},
+        "model_config": {"model_path": None, "device": 0, "dataparallel": True, "distributed_backend": "nccl"},
         "learner_config": {
             "fp16": False,
             "fp16_opt_level": "O1",
@@ -204,7 +204,7 @@ def test_checkpoint_metric(caplog):
             "use_exact_log_path": False,
         },
         "data_config": {"min_data_len": 0, "max_data_len": 0},
-        "model_config": {"model_path": None, "device": 0, "dataparallel": True},
+        "model_config": {"model_path": None, "device": 0, "dataparallel": True, "distributed_backend": "nccl"},
         "learner_config": {
             "fp16": False,
             "fp16_opt_level": "O1",

--- a/tests/utils/test_parse_args.py
+++ b/tests/utils/test_parse_args.py
@@ -27,7 +27,6 @@ def test_parse_args(caplog):
         ]
     )
     assert args.seed == 0
-
     config = parse_args_to_config(args)
 
     assert config == {
@@ -185,6 +184,7 @@ def test_checkpoint_metric(caplog):
     # Test different checkpoint_metric
     dirpath = "temp_parse_args"
     Meta.reset()
+    
     emmental.init(
         log_dir=dirpath,
         config={

--- a/tests/utils/test_parse_args.py
+++ b/tests/utils/test_parse_args.py
@@ -37,7 +37,12 @@ def test_parse_args(caplog):
             "use_exact_log_path": False,
         },
         "data_config": {"min_data_len": 0, "max_data_len": 0},
-        "model_config": {"model_path": None, "device": 0, "dataparallel": True, "distributed_backend": "nccl"},
+        "model_config": {
+            "model_path": None,
+            "device": 0,
+            "dataparallel": True,
+            "distributed_backend": "nccl",
+        },
         "learner_config": {
             "fp16": False,
             "fp16_opt_level": "O1",
@@ -184,7 +189,7 @@ def test_checkpoint_metric(caplog):
     # Test different checkpoint_metric
     dirpath = "temp_parse_args"
     Meta.reset()
-    
+
     emmental.init(
         log_dir=dirpath,
         config={
@@ -204,7 +209,12 @@ def test_checkpoint_metric(caplog):
             "use_exact_log_path": False,
         },
         "data_config": {"min_data_len": 0, "max_data_len": 0},
-        "model_config": {"model_path": None, "device": 0, "dataparallel": True, "distributed_backend": "nccl"},
+        "model_config": {
+            "model_path": None,
+            "device": 0,
+            "dataparallel": True,
+            "distributed_backend": "nccl",
+        },
         "learner_config": {
             "fp16": False,
             "fp16_opt_level": "O1",


### PR DESCRIPTION
## Description of the problems or issues
- Added support to specify the DDP backend between NCCL and GLOO. GLOO supports sparse tensors (common for embeddings) while NCCL does not.
- DDP requires that all modules have learnable parameters. When DDP was called on each module separately, an error would be thrown if one module had no learnable params.
 
## Description of the proposed changes
- Add a `distributed_backend` flag to model_config. This could be moved to `learner_config` if desired.
- Added a check to pass on calling DDP on modules without any `requires_grad` param.

## Test plan
- Updated parse arg tests to add the distributed backend config.
- DDP isn't currently in the tests, but I did test out locally running a DDP model with the gloo backend successfully.