### PR TITLE
Fix TensorBoardWriter error when optimizer config has `parameters` key

### DIFF
--- a/src/emmental/logging/tensorboard_writer.py
+++ b/src/emmental/logging/tensorboard_writer.py
@@ -49,9 +49,11 @@ class TensorBoardWriter(LogWriter):
         Args:
           config_filename: The config filename, defaults to "config.yaml".
         """
-        config = json.dumps(Meta.config)
-        self.writer.add_text(tag="config", text_string=config)
-
+        try:
+          config = json.dumps(Meta.config)
+          self.writer.add_text(tag="config", text_string=config)
+        except TypeError:
+          pass
         super().write_config(config_filename)
 
     def write_log(self, log_filename: str = "log.json") -> None:


### PR DESCRIPTION
The call to `json.dumps` in `TensorBoardWriter.write_config` throws a `TypeError` when the optimizer config has the `parameters` key assigned to a function e.g. like https://github.com/senwu/dauphin/blob/master/dauphin/text/text.py#L40-L66. Problem: can't serialize the function.

Adds a hotfix where the json dumps is skipped if the TypeError is thrown. Ideally, should just remove the offending keys and json dumps the rest.
