### PR TITLE
Fix NoneType issue in collate_fn when using python 3.8+ on mac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Fixed
 
 * `@senwu`_: Fix the metric cannot calculate issue when scorer is none.
   (`#112 <https://github.com/senwu/emmental/pull/112>`_)
+* `@senwu`_: Fix Meta.config is None issue in collate_fn with num_workers > 1 when
+  using python 3.8+ on mac.
+  (`#117 <https://github.com/senwu/emmental/pull/117>`_)
+
 
 Added
 ^^^^^

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -1,13 +1,14 @@
 """Emmental dataset and dataloader unit tests."""
 import logging
 import shutil
+from functools import partial
 
 import pytest
 import torch
 
 import emmental
 from emmental import Meta
-from emmental.data import EmmentalDataLoader, EmmentalDataset
+from emmental.data import EmmentalDataLoader, EmmentalDataset, emmental_collate_fn
 
 
 def test_emmental_dataset(caplog):
@@ -163,6 +164,7 @@ def test_emmental_dataloader(caplog):
         dataset=dataset,
         split="test",
         batch_size=3,
+        collate_fn=partial(emmental_collate_fn, min_data_len=0, max_data_len=0),
     )
 
     x_batch, y_batch = next(iter(dataloader2))

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -145,6 +145,7 @@ def test_emmental_dataloader(caplog):
         dataset=dataset,
         split="train",
         batch_size=2,
+        num_workers=2,
     )
 
     x_batch, y_batch = next(iter(dataloader1))

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -39,6 +39,7 @@ def test_e2e(caplog):
             "online_eval": True,
             "optimizer_config": {"lr": 0.01, "grad_clip": 100},
         },
+        "data_config": {"max_data_len": 10},
         "logging_config": {
             "counter_unit": "epoch",
             "evaluation_freq": 0.2,
@@ -137,18 +138,21 @@ def test_e2e(caplog):
         dataset=train_dataset1,
         split="train",
         batch_size=10,
+        num_workers=2,
     )
     dev_dataloader1 = EmmentalDataLoader(
         task_to_label_dict=task_to_label_dict,
         dataset=dev_dataset1,
         split="valid",
         batch_size=10,
+        num_workers=2,
     )
     test_dataloader1 = EmmentalDataLoader(
         task_to_label_dict=task_to_label_dict,
         dataset=test_dataset1,
         split="test",
         batch_size=10,
+        num_workers=2,
     )
 
     task_to_label_dict = {"task2": "label2"}


### PR DESCRIPTION
## Description of the problems or issues

On Mac with python 3.8+ multiprocessing uses `spawn` to start multiple process and it won't inherit from the origin process which causes `Meta.config` is None. This results `emmental_collate_fn` cannot get `min_data_len` and `max_data_len` from `Meta.config`.


## Description of the proposed changes
Instead get `min_data_len` and `max_data_len` from `Meta.config` in `Emmental_collate_fn`, we set those two variables in the `EmmentalDataLoader`.

## Test plan
Passes the existing test.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
* [x] I have updated the CHANGELOG.rst accordingly.
